### PR TITLE
package flatpak

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
         "AppImage",
         "deb",
         "rpm",
-        "snap"
+        "snap",
+        "flatpak"
       ]
     }
   }


### PR DESCRIPTION
يمكنك تثبيت الحزمة بـ
`flatpak install dist/Altaqwaa-2.0.0-x86_64.flatpak `
لكن لانستطيع رفعها الى [Flathub.org](https://Flathub.org) لأنه يتطلب ملف yaml فيه اوامر البناء ووصف للحزمة ويتم البناء في [buildbot.flathub.org](https://buildbot.flathub.org)

هذا كافي لرفع الحزم الى [Altaqwaa-Islamic-Desktop-Application/releases](https://github.com/rn0x/Altaqwaa-Islamic-Desktop-Application/releases) 
