### PR TITLE
v8 compile cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+require('v8-compile-cache');
 const { BrowserWindow, ipcMain, app, Tray, Menu, globalShortcut } = require('electron');
 const path = require('path');
 const homeWindow = require('./Window/home.js');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "moment-hijri": "^2.1.2",
     "moment-timezone": "^0.5.34",
     "node-fetch": "^2.6.7",
-    "request": "^2.88.2"
+    "request": "^2.88.2",
+    "v8-compile-cache": "^2.3.0"
   },
   "devDependencies": {
     "electron": "19.0.10",


### PR DESCRIPTION
To enable [code caching](https://v8.dev/blog/code-caching) which will speed up instantiation time of the app (better performance).