### PR TITLE
Change app id to org.altaqwaa.Altaqwaa

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "repo": "Altaqwaa-Islamic-Desktop-Application",
       "protocol": "https"
     },
-    "appId": "org.altaqwaa.rn0x",
+    "appId": "org.altaqwaa.Altaqwaa",
     "copyright": "Copyleft 🄯 2023 Altaqwaa",
     "win": {
       "icon": "./src/build/icons/icon.ico",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const path = require('path');
 const fs = require('fs-extra');
 
 /* App Initialization (Make Sure Files Ready)  */
-app.setAppUserModelId("org.altaqwaa.rn0x");
+app.setAppUserModelId("org.altaqwaa.Altaqwaa");
 const appInitialization = require('./modules/appInitialization.js');
 const App_Path = path.join(app?.getPath("appData"), './altaqwaa');
 


### PR DESCRIPTION
السبب تغير الاسم هنا أيضًا لتجنب مشاكل الاختلاف من هنا وFlatpak

زي ما قلت قبل كدة ، الاسم الحالي مش بيتبع مواصفات Freedesktop
https://docs.flatpak.org/en/latest/conventions.html#application-ids
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic
https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names

متنساش برضو تحدث [README.md](https://github.com/rn0x/Altaqwaa-Islamic-Desktop-Application/blob/d04f4935c39c321b4946d5ab8c8d510f8229f655/README.md#%D8%AF%D8%B9%D9%85-%D9%84%D9%8A%D9%86%D9%83%D8%B3) لما ترفع إصدار جديد.
